### PR TITLE
Fractured mesh

### DIFF
--- a/examples/analytical_1d.jl
+++ b/examples/analytical_1d.jl
@@ -128,7 +128,6 @@ function convergence_1d(setup_fn, type = :space; Nx = 2 .^(range(3, 6)), Nt = 2 
             out = setup_fn(nx, nt)
             case, sol, x, t = out
             dt = t[2] - t[1]
-            println("dx = $dx, dt = $dt")
             push!(Δt, dt)
             
             sim, cfg = setup_reservoir_simulator(case;

--- a/examples/btes.jl
+++ b/examples/btes.jl
@@ -11,7 +11,7 @@ using HYPRE
 # We consider a domain with 50 BTES wells that all reach 100 m depth. The BTES
 # wells are charged during the summer months and discharged during the winter
 # months. The simulation is run for 10 years.
-case = btes(num_wells = 50, depth = 100;
+case = btes(num_wells = 50, depths = [0.0, 0.5, 100, 125],
     charge_months = ["April", "May", "June", "July", "August", "September"],
     discharge_months = ["October", "November", "December", "January", "February", "March"],
     num_years = 10,
@@ -40,7 +40,7 @@ for ws in well_symbols(case.model)
 end
 
 ## ## Simulate the case
- results = simulate_reservoir(case, simulator=simulator, config=config, info_level=2);
+results = simulate_reservoir(case, simulator=simulator, config=config, info_level=2);
 
 ## ## Visualize the results
 

--- a/src/Fimbul.jl
+++ b/src/Fimbul.jl
@@ -6,9 +6,11 @@ module Fimbul
     using Gmsh
     using Meshes
     include("meshing/extruded.jl")
+    include("meshing/fractured.jl")
     include("meshing/utils.jl")
 
-    export fibonacci_pattern_2d, extruded_mesh
+    export fibonacci_pattern_2d
+    export extruded_mesh, horizontal_fractured_mesh
 
     # Cases
     using Dates

--- a/src/Fimbul.jl
+++ b/src/Fimbul.jl
@@ -21,6 +21,7 @@ module Fimbul
     include("cases/btes.jl")
 
     export make_utes_schedule
+    export set_dirichlet_bcs
     export egg_geothermal, egg_geothermal_doublet, egg_ates
     export analytical_1d
     export btes

--- a/src/cases/btes.jl
+++ b/src/cases/btes.jl
@@ -7,53 +7,67 @@ darcy = si_unit(:darcy)
 
 function btes(;
     num_wells = 50,
-    depth = 50,
+    well_spacing = 5.0,
+    depths = [0.0, 0.5, 50, 65],
+    well_layers = [1, 2],
+    density = [30, 2580, 2580]*kilogram/meter^3,
+    thermal_conductivity = [0.034, 3.7, 3.7]*watt/meter/Kelvin,
+    heat_capacity = [1500, 900, 900]*joule/kilogram/Kelvin,
+    geothermal_gradient = 0.03Kelvin/meter,
     temperature_charge = to_kelvin(90.0),
     temperature_discharge = to_kelvin(10.0),
     rate_charge = 0.5litre/second,
     rate_discharge = rate_charge,
     temperature_surface = to_kelvin(10.0),
-    geothermal_gradient = 0.03Kelvin/meter,
     num_years = 5,
     years = missing,
     charge_months = ["June", "July", "August", "September"],
     discharge_months = ["December", "January", "February", "March"],
     report_interval = 14day,
+    n_z = [4, 10, 3],
+    n_xy = 5,
     mesh_args = NamedTuple(),
     )
 
     # ## Create mesh
-    x = fibonacci_pattern_2d(num_wells; spacing = 5.0)
+    x = fibonacci_pattern_2d(num_wells; spacing = well_spacing)
     well_coordinates = map(x -> [x], x)
-    depths = [0.0, depth, 1.25*depth]
-    hz = [2.5, 10.0]
-    mesh, layers, metrics = extruded_mesh(well_coordinates, depths; hz = hz, mesh_args...)
+    hz = diff(depths)./n_z
+    println(hz)
+    hxy = well_spacing/n_xy
+    mesh, layers, metrics = extruded_mesh(well_coordinates, depths;
+        hxy_min = hxy, hz = hz, mesh_args...)
 
     # ## Set up model
-    # Set up reservoir domain with rock properties similar to that of granite
+    # Set up reservoir domain with rock properties similar to that of granite,
+    # with a styrofoam layer on top
+    density = density[layers]
+    thermal_conductivity = thermal_conductivity[layers]
+    heat_capacity = heat_capacity[layers]
     domain = reservoir_domain(mesh,
         permeability = 1e-6darcy,
         porosity = 0.01,
-        rock_density = 2650kilogram/meter^3,
-        rock_heat_capacity = 790joule/kilogram/Kelvin,
-        rock_thermal_conductivity = 3.0watt/meter/Kelvin,
-        component_heat_capacity = 4.278e3joule/kilogram/Kelvin
-    );
+        rock_density = density,
+        rock_heat_capacity = heat_capacity,
+        rock_thermal_conductivity = thermal_conductivity,
+        component_heat_capacity = 4.278e3joule/kilogram/Kelvin,
+    )
     # Set up BTES wells
     hxy_min = metrics.hxy_min
     well_models = []
     nl = length(layers)
     geo = tpfv_geometry(mesh)
     for (wno, xw) in enumerate(well_coordinates)
-        println("Adding well $wno")
+        name = Symbol("B$wno")
+        println("Adding well $name ($wno/$num_wells)")
         xw = xw[1]
         d = max(norm(xw, 2))
         v = (d > 0) ? xw./d : (1.0, 0.0)
         # Shift coordiates a bit to avoid being exactly on the node
         xw = xw .+ (hxy_min/2) .* v
-        trajectory = [xw[1] xw[2] 0.0; xw[1] xw[2] depths[2]]
+        trajectory = [xw[1] xw[2] 0.0; xw[1] xw[2] depths[end]]
         cells = Jutul.find_enclosing_cells(mesh, trajectory, n = 100)
-        name = Symbol("B$wno")
+        filter!(c -> layers[c] ∈ well_layers, cells)
         w_sup, w_ret = setup_btes_well(domain, cells, name=name, btes_type=:u1)
         push!(well_models, w_sup, w_ret)
     end

--- a/src/meshing/dev_meshing.jl
+++ b/src/meshing/dev_meshing.jl
@@ -1,11 +1,9 @@
-using Fimbul
 
-##
-<<<<<<< Updated upstream
 xw = fibonacci_pattern_2d(100; radius = missing, spacing = 5.0)
+cell_constraints = map(x -> [x], xw)
 
-##
-mesh, m = extruded_mesh(xw, [0, 50.0, 75.0], hz = [0.5, 5.0])
+depths = [0.0, 10.0, 20, 30]
+mesh, layers, metrics = horizontal_fractured_mesh(cell_constraints, depths, 10; aperture = 1e-3)
 
 ##
 using GLMakie
@@ -16,11 +14,3 @@ ax = Axis3(fig[1, 1], zreversed = true)
 Jutul.plot_mesh_edges!(ax, mesh, alpha = 0.5)
 fig
 
-##
-x, xc = Fimbul.get_convex_hull(xw)
-
-v = map(x -> x .- xc, x)
-v = map(v -> v./norm(v,2), v)
-
-<<<<<<< Updated upstream
-xb = Fimbul.offset_boundary(x, xc, 50)

--- a/src/meshing/extruded.jl
+++ b/src/meshing/extruded.jl
@@ -177,7 +177,7 @@ function interpolate_z(depths, hz;
         z_top = interpolate_z(z_0, z_0t, hz_prev, hz_curr)
         z_mid = interpolate_z(z_0t, z_1t, hz_curr, hz_curr)
         z_bottom = interpolate_z(z_1t, z_1, hz_curr, hz_next)
-        z_i = unique(vcat(z_top, z_mid, z_bottom))
+        z_i = unique(vcat(z_top[1:end-1], z_mid[1:end-1], z_bottom[1:end]))
 
         push!(z, z_i[1:end-1]...)
         unique!(z)

--- a/src/meshing/extruded.jl
+++ b/src/meshing/extruded.jl
@@ -100,6 +100,10 @@ function extruded_mesh(cell_constraints, depths;
     mesh = Jutul.mesh_from_gmsh(z_is_depth=true)
     gmsh.finalize()
 
+    nl = length(layers)
+    nc_2d = Int(number_of_cells(mesh)/nl)
+    layers = repeat(layers, nc_2d)
+
     metrics = (hxy_min = hxy_min, hxy_max = hxy_max, hz = hz,
         dist_min = dist_min, dist_max = dist_max)
 

--- a/src/meshing/extruded.jl
+++ b/src/meshing/extruded.jl
@@ -24,8 +24,8 @@ function extruded_mesh(cell_constraints, depths;
         @assert ismissing(offset_rel)
     end
 
-    xb_outer, = offset_boundary(x_cc, offset)
-    xb_outer = vcat(xb_outer, xb_outer[1])
+    xb_outer = offset_boundary(x_cc, offset; n = 12)
+    xb_outer = push!(xb_outer, xb_outer[1])
     perimeter = curve_measure(xb_outer)
 
     # Set mesh sizes
@@ -69,7 +69,7 @@ function extruded_mesh(cell_constraints, depths;
     if !isempty(tag1d_cc)
         gmsh.model.mesh.field.setNumbers(1, "CurvesList", tag1d_cc)
     end
-     gmsh.model.mesh.field.add("Threshold", 2)
+    gmsh.model.mesh.field.add("Threshold", 2)
     gmsh.model.mesh.field.setNumber(2, "InField", 1)
     gmsh.model.mesh.field.setNumber(2, "SizeMin", hxy_min)
     gmsh.model.mesh.field.setNumber(2, "SizeMax", hxy_max)
@@ -106,7 +106,8 @@ function extruded_mesh(cell_constraints, depths;
     layers = repeat(layers, nc_2d)
 
     metrics = (hxy_min = hxy_min, hxy_max = hxy_max, hz = hz, 
-        offset = offset, dist_min = dist_min, dist_max = dist_max)
+        offset = offset, dist_min = dist_min, dist_max = dist_max, 
+        boundary = xb_outer)
 
     return mesh, layers, metrics
 

--- a/src/meshing/extruded.jl
+++ b/src/meshing/extruded.jl
@@ -38,8 +38,8 @@ function extruded_mesh(cell_constraints, depths;
     xb_outer = vcat(xb_outer, xb_outer[1])
     perimeter = curve_measure(xb_outer)
    
-    @assert 0.0 < hxy_min < hxy_max < perimeter/4
-    "Please ensure that 0 < hxy_min < hxy_max < perimeter/4"
+    @assert 0.0 < hxy_min < hxy_max < perimeter/4 "Please ensure that "*
+        "0 < hxy_min = $hxy_min < hxy_max = $hxy_max < perimeter/4 = $(perimeter/4)"
     hz = ismissing(hz) ? depth/50 : hz
         
     # ## Create 2D mesh
@@ -50,13 +50,13 @@ function extruded_mesh(cell_constraints, depths;
     i0, i1 = tag0d_bdr[end], tag1d_brd[end]
     for (i, cc) in enumerate(cell_constraints)
         if length(cc) == 1
-            t0d_i, = add_geometry_0d(cc, hxy_min, i0, true)
-            push!(tag0d_cc, t0d_i)
+            t0d_i = add_geometry_0d(cc, hxy_min, i0, true)
+            push!(tag0d_cc, t0d_i...)
             i0 += 1
         else
             t1d_i, t0d_i = add_geometry_1d(cc, hxy_min, i1, i0, true)
             push!(tag1d_cc, t1d_i...)
-            i1 += 1
+            i1 += length(t1d_i)
             i0 += length(t0d_i)
         end
     end

--- a/src/meshing/extruded.jl
+++ b/src/meshing/extruded.jl
@@ -29,7 +29,7 @@ function extruded_mesh(cell_constraints, depths;
         hxy_max = 2*π*(max_cc_distance/2 + offset)/10
     end
     
-    xb_outer = offset_boundary(x_cc, offset, hxy_max)
+    xb_outer, = offset_boundary(x_cc, offset, hxy_max)
     
     radius_inner = max_cc_distance/2
     radius_outer = max_distance(xb_outer)/2
@@ -104,8 +104,8 @@ function extruded_mesh(cell_constraints, depths;
     nc_2d = Int(number_of_cells(mesh)/nl)
     layers = repeat(layers, nc_2d)
 
-    metrics = (hxy_min = hxy_min, hxy_max = hxy_max, hz = hz,
-        dist_min = dist_min, dist_max = dist_max)
+    metrics = (hxy_min = hxy_min, hxy_max = hxy_max, hz = hz, 
+        offset = offset, dist_min = dist_min, dist_max = dist_max)
 
     return mesh, layers, metrics
 

--- a/src/meshing/fractured.jl
+++ b/src/meshing/fractured.jl
@@ -14,6 +14,8 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
 
     z = [depths[1]]
     hz_all = []
+    layer_map = []
+    fracture_map = []
     for i = 1:length(depths)-1
         dz = depths[i+1] - depths[i]
         if num_fractures[i] > 0
@@ -29,6 +31,7 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
             end
             hzi = fill(hzi, 2*nf-1)
             @assert isapprox(zi[end], depths[i+1])
+            fmap = fill([true, false], nf)[1:end-1]
         else
             zi = depths[i+1]
             if ismissing(hz)
@@ -36,7 +39,11 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
             else
                 hzi = hz[i]
             end
+            fmap = false
         end
+        nl = length(zi)-1
+        push!(layer_map, fill(i, nl)...)
+        push!(fracture_map, fmap...)
         push!(z, zi...)
         push!(hz_all, hzi...)
     end

--- a/src/meshing/fractured.jl
+++ b/src/meshing/fractured.jl
@@ -13,8 +13,11 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
         @assert length(hz) == length(depths)-1
     end
 
-    interpolation0 = copy(interpolation)
-    interpolation = Symbol[]
+    interp_per_layer = !(interpolation isa Symbol)
+    if interp_per_layer 
+        interpolation0 = copy(interpolation)
+        interpolation = Symbol[]
+    end
 
     z = [depths[1]]
     hz_all = []
@@ -51,7 +54,7 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
         push!(fracture_map, fmap...)
         push!(z, zi...)
         push!(hz_all, hzi...)
-        if !(interpolation0 isa Symbol)
+        if interp_per_layer
             push!(interpolation, fill(interpolation0[i], nl)...)
         end
     end

--- a/src/meshing/fractured.jl
+++ b/src/meshing/fractured.jl
@@ -14,7 +14,7 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
 
     z = [depths[1]]
     hz_all = []
-    layer_map = []
+    layer_map = Int64[]
     fracture_map = []
     for i = 1:length(depths)-1
         dz = depths[i+1] - depths[i]
@@ -31,7 +31,7 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
             end
             hzi = fill(hzi, 2*nf-1)
             @assert isapprox(zi[end], depths[i+1])
-            fmap = fill([true, false], nf)[1:end-1]
+            fmap = repeat([true, false], nf)[1:end-1]
         else
             zi = depths[i+1]
             if ismissing(hz)
@@ -41,7 +41,8 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
             end
             fmap = false
         end
-        nl = length(zi)-1
+        nl = length(zi)
+        @assert length(fmap) == nl
         push!(layer_map, fill(i, nl)...)
         push!(fracture_map, fmap...)
         push!(z, zi...)
@@ -49,5 +50,10 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
     end
 
     mesh, layers, metrics = extruded_mesh(cell_constraints, z; hz = hz_all, kwargs...)
+    
+    fractures = fracture_map[layers]
+    layers = layer_map[layers]
+    
+    return mesh, layers, fractures, metrics
 
 end

--- a/src/meshing/fractured.jl
+++ b/src/meshing/fractured.jl
@@ -1,6 +1,7 @@
 function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
         aperture = 1e-3,
         hz = missing,
+        interpolation = :default,
         kwargs...
     )
 
@@ -11,6 +12,9 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
     if !ismissing(hz)
         @assert length(hz) == length(depths)-1
     end
+
+    interpolation0 = copy(interpolation)
+    interpolation = Symbol[]
 
     z = [depths[1]]
     hz_all = []
@@ -47,9 +51,13 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
         push!(fracture_map, fmap...)
         push!(z, zi...)
         push!(hz_all, hzi...)
+        if !(interpolation0 isa Symbol)
+            push!(interpolation, fill(interpolation0[i], nl)...)
+        end
     end
 
-    mesh, layers, metrics = extruded_mesh(cell_constraints, z; hz = hz_all, kwargs...)
+    mesh, layers, metrics = extruded_mesh(cell_constraints, z; 
+        hz = hz_all, interpolation = interpolation, kwargs...)
 
     fractures = fracture_map[layers]
     layers = layer_map[layers]

--- a/src/meshing/fractured.jl
+++ b/src/meshing/fractured.jl
@@ -1,0 +1,46 @@
+function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
+        aperture = 1e-3,
+        hz = missing,
+        kwargs...
+    )
+
+    if length(num_fractures) == 1
+        @assert length(depths) == 4
+        num_fractures = [0, num_fractures, 0]
+    end
+    if !ismissing(hz)
+        @assert length(hz) == length(depths)-1
+    end
+
+    z = [depths[1]]
+    hz_all = []
+    for i = 1:length(depths)-1
+        dz = depths[i+1] - depths[i]
+        if num_fractures[i] > 0
+            @assert num_fractures[i] > 1
+            nf = num_fractures[i]
+            dz_mat = (dz - nf*aperture)/(nf-1)
+            dz = repeat([aperture, dz_mat], nf)[1:end-1]
+            zi = cumsum(dz) .+ depths[i]
+            if ismissing(hz)
+                hzi = dz_mat/5
+            else
+                hzi = hz[i]
+            end
+            hzi = fill(hzi, 2*nf-1)
+            @assert isapprox(zi[end], depths[i+1])
+        else
+            zi = depths[i+1]
+            if ismissing(hz)
+                hzi = dz/3
+            else
+                hzi = hz[i]
+            end
+        end
+        push!(z, zi...)
+        push!(hz_all, hzi...)
+    end
+
+    mesh, layers, metrics = extruded_mesh(cell_constraints, z; hz = hz_all, kwargs...)
+
+end

--- a/src/meshing/fractured.jl
+++ b/src/meshing/fractured.jl
@@ -15,23 +15,23 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
     z = [depths[1]]
     hz_all = []
     layer_map = Int64[]
-    fracture_map = []
+    fracture_map = Bool[]
     for i = 1:length(depths)-1
         dz = depths[i+1] - depths[i]
         if num_fractures[i] > 0
             @assert num_fractures[i] > 1
             nf = num_fractures[i]
-            dz_mat = (dz - nf*aperture)/(nf-1)
-            dz = repeat([aperture, dz_mat], nf)[1:end-1]
+            dz_mat = (dz - nf*aperture)/(nf+1)
+            dz = repeat([dz_mat, aperture], nf+1)[1:end-1]
             zi = cumsum(dz) .+ depths[i]
             if ismissing(hz)
                 hzi = dz_mat/5
             else
                 hzi = hz[i]
             end
-            hzi = fill(hzi, 2*nf-1)
+            hzi = fill(hzi, 2*nf+1)
             @assert isapprox(zi[end], depths[i+1])
-            fmap = repeat([true, false], nf)[1:end-1]
+            fmap = repeat([false, true], nf+1)[1:end-1]
         else
             zi = depths[i+1]
             if ismissing(hz)
@@ -50,7 +50,7 @@ function horizontal_fractured_mesh(cell_constraints, depths, num_fractures;
     end
 
     mesh, layers, metrics = extruded_mesh(cell_constraints, z; hz = hz_all, kwargs...)
-    
+
     fractures = fracture_map[layers]
     layers = layer_map[layers]
     

--- a/src/meshing/utils.jl
+++ b/src/meshing/utils.jl
@@ -33,9 +33,9 @@ end
 
 function offset_boundary(x, offset, h)
 
-    @assert offset > 0 "offset must be larger than 0"
+    @assert offset > 0 "Offset must be larger than 0"
     
-    n = max(Int(ceil(2π*offset/h)), 6)
+    n = max(Int(ceil(2π*offset/h)), 12)
 
     function sample_circle(x0, r)
 

--- a/src/meshing/utils.jl
+++ b/src/meshing/utils.jl
@@ -20,20 +20,69 @@ function fibonacci_pattern_2d(num_points; spacing = 5.0, radius = missing)
 
 end
 
-function get_convex_hull(x)
+function centroid(x)
 
     ptset = PointSet(x)
-    println(ptset)
-    ch = convexhull(ptset)
-    x = map(p -> Tuple(p.coords), vertices(ch))
-
-    return x, ch
+    xc = Meshes.centroid(ptset)
+    
+    return Tuple(xc.coords)
 
 end
 
-function offset_boundary(x, offset, n = 12)
+# function get_convex_hull(x)
+
+#     ptset = PointSet(x)
+#     println(ptset)
+#     poly = convexhull(ptset)
+#     x = map(p -> Tuple(p.coords), vertices(poly))
+#     x = vcat(x...)
+
+#     return x
+
+# end
+
+function get_convex_hull(points)
+    # Ensure there are at least 3 points
+    @assert length(points) ≥ 3 "At least 3 points are required to compute a convex hull."
+
+    # Helper function to compute the cross product of vectors (p1 -> p2) and (p1 -> p3)
+    function cross_product(p1, p2, p3)
+        (p2[1] - p1[1]) * (p3[2] - p1[2]) - (p2[2] - p1[2]) * (p3[1] - p1[1])
+    end
+
+    # Start with the leftmost point
+    hull = Vector{Tuple{Float64, Float64}}()
+    start = argmin(map(p -> p[1], points))  # Index of the leftmost point
+    current = start
+
+    while true
+        push!(hull, points[current])  # Add the current point to the hull
+        next_point = mod1(current + 1, length(points))  # Next candidate point
+
+        for i in 1:length(points)
+            if cross_product(points[current], points[next_point], points[i]) < 0
+                next_point = i  # Update the next point if it is more counterclockwise
+            end
+        end
+
+        current = next_point  # Move to the next point
+        if current == start
+            break  # Stop when we return to the starting point
+        end
+    end
+
+    return hull
+end
+
+
+function offset_boundary(x, offset; h = missing, n = 6)
 
     @assert offset > 0 "Offset must be larger than 0"
+
+    # Number of points to sample around each point
+    if !ismissing(h)
+        n = max(Int(ceil(2π*offset/h)) + 1, n)
+    end
 
     function sample_circle(x0, r)
 
@@ -89,6 +138,32 @@ function max_distance(x)
     
 end
 
+"""
+Determines whether a set of points is inside a polygon.
+
+# Arguments
+- `points::Vector{Tuple{Float64, Float64}}`: A vector of points (x, y) to check.
+- `polygon::Vector{Tuple{Float64, Float64}}`: A vector of points (x, y) representing the vertices of the polygon.
+
+# Returns
+- `Vector{Bool}`: A vector of booleans where `true` indicates the corresponding point is inside the polygon.
+"""
+function point_in_polygon(point::Tuple{Float64, Float64}, polygon)
+    x, y = point
+    n = length(polygon)
+    inside = false
+    j = n
+    for i in 1:n
+        xi, yi = polygon[i]
+        xj, yj = polygon[j]
+        if (yi > y) != (yj > y) && (x < (xj - xi) * (y - yi) / (yj - yi) + xi)
+            inside = !inside
+        end
+        j = i
+    end
+    return inside
+end
+
 function add_geometry_0d(points, h, tag = 0, embed = false)
 
     tags = Vector{Int}(undef, length(points))
@@ -109,9 +184,13 @@ function add_geometry_1d(points, h, tag_1d = 0, tag_0d = 0, embed = false)
     
     np = length(points)
     tags = Vector{Int}(undef, np-1)
-    tags_0d = add_geometry_0d(points, h, tag_0d, embed)
+    n = (points[1] == points[end]) ? np-1 : np
+
+    tags_0d = add_geometry_0d(points[1:n], h, tag_0d)
     for i = 1:np-1
-        tags[i] = gmsh.model.geo.addLine(tags_0d[i], tags_0d[i+1], tag_1d + i)
+        start = i
+        stop = (i + 1 - 1)%n + 1
+        tags[i] = gmsh.model.geo.addLine(tags_0d[start], tags_0d[stop], tag_1d + i)
     end
     if embed
         gmsh.model.geo.synchronize()
@@ -125,7 +204,6 @@ end
 function add_geometry_2d(points, h, tag_2d = 0, tag_1d = 0, tag_0d = 0, embed = false)
 
     tags_1d, tags_0d = add_geometry_1d(points, h, tag_1d, tag_0d, embed)
-    println(tags_1d)
     tag = gmsh.model.geo.addCurveLoop(tags_1d)
     gmsh.model.geo.addPlaneSurface([tag], tag_2d + 1)
 

--- a/src/meshing/utils.jl
+++ b/src/meshing/utils.jl
@@ -34,9 +34,6 @@ end
 function offset_boundary(x, offset, n = 12)
 
     @assert offset > 0 "Offset must be larger than 0"
-    
-    # if ismissing(h)
-    # n = max(Int(ceil(2π*offset/h)), 12)
 
     function sample_circle(x0, r)
 

--- a/src/meshing/utils.jl
+++ b/src/meshing/utils.jl
@@ -31,11 +31,12 @@ function get_convex_hull(x)
 
 end
 
-function offset_boundary(x, offset, h)
+function offset_boundary(x, offset, n = 12)
 
     @assert offset > 0 "Offset must be larger than 0"
     
-    n = max(Int(ceil(2π*offset/h)), 12)
+    # if ismissing(h)
+    # n = max(Int(ceil(2π*offset/h)), 12)
 
     function sample_circle(x0, r)
 

--- a/src/meshing/utils.jl
+++ b/src/meshing/utils.jl
@@ -27,7 +27,7 @@ function get_convex_hull(x)
     ch = convexhull(ptset)
     x = map(p -> Tuple(p.coords), vertices(ch))
 
-    return x
+    return x, ch
 
 end
 

--- a/src/visualization/well_data_plotting.jl
+++ b/src/visualization/well_data_plotting.jl
@@ -15,7 +15,6 @@ function plot_well_data(time, reference, other;
 
     for well in wells
         vr = get_field(reference, well, field)
-        println(vr)
         lines!(ax, time, vr; label=names[1], linestyle = (:dash, 1), linewidth = 6, color = :black)
         for (i, proxy) in enumerate(other)
             vp = get_field(proxy, well, field)

--- a/test/meshing.jl
+++ b/test/meshing.jl
@@ -1,0 +1,37 @@
+using Jutul, JutulDarcy, Fimbul, Test, LinearAlgebra
+
+@testset "Extruded mesh" begin
+
+    # Test functionality for interpolation in z-direction
+    depths = [0.0, 10.0, 100.0, 101.0]
+    hz = [2.5, 10.0, 0.1]
+    z, layers = Fimbul.interpolate_z(depths, hz)
+    ok = true
+    for l = 1:length(depths)-1
+        layer_ix = findall(layers .== l)
+        zl = z[layer_ix[1]:layer_ix[end]+1]
+        @test zl[1] == depths[l]
+        @test zl[end] == depths[l+1]
+        dz = diff(zl)
+        if 1 < l < length(depths)-1
+            @test isapprox(maximum(dz), hz[l])
+        else
+            @test all(isapprox.(dz, hz[l]))
+        end
+    end
+
+    # Check extruded mesh with cell constraints
+    x = fibonacci_pattern_2d(10, spacing = 5.0)
+    cc = map(x -> [x], x)
+    depths = [0.0, 10.0, 50.0, 100.0]
+    hz = [2.5, 10.0, 25.0]
+    mesh, layers, metrics = extruded_mesh(cc, depths; hz = hz)
+    @test unique(layers) == collect(1:length(depths)-1)
+    for xi in x
+        xi = [xi[1], xi[2]]
+        d = map(xn -> norm(xn[1:2] .- xi,2), mesh.node_points)
+        ix = isapprox.(d, 0.0)
+        @test sum(ix) == length(layers)+1
+    end
+
+end


### PR DESCRIPTION
This pull request introduces several significant changes to the meshing capabilities of Fimbul, introducing support for horizontally fractured meshes.

### Meshing Enhancements:
* Added a new function `horizontal_fractured_mesh` to create meshes with horizontal fractures, including support for specifying the number of fractures and their apertures. (`src/meshing/fractured.jl`)
* Updated the `extruded_mesh` function to include an `interpolation` parameter, allowing for more flexible layer transitions. (`src/meshing/extruded.jl`) [[1]](diffhunk://#diff-32279d0f5c1405497899db195540628a8001055f763d031f0cb7f25b4f48bde7R4) [[2]](diffhunk://#diff-32279d0f5c1405497899db195540628a8001055f763d031f0cb7f25b4f48bde7R18-R43) [[3]](diffhunk://#diff-32279d0f5c1405497899db195540628a8001055f763d031f0cb7f25b4f48bde7L53-R60) [[4]](diffhunk://#diff-32279d0f5c1405497899db195540628a8001055f763d031f0cb7f25b4f48bde7L91-R91) [[5]](diffhunk://#diff-32279d0f5c1405497899db195540628a8001055f763d031f0cb7f25b4f48bde7R104-R117) [[6]](diffhunk://#diff-32279d0f5c1405497899db195540628a8001055f763d031f0cb7f25b4f48bde7L123-R180)

### Boundary Conditions:
* Introduced a new function `set_dirichlet_bcs` to set Dirichlet boundary conditions for pressure and temperature, including initial conditions based on a geothermal gradient. (`src/cases/utils.jl`)

### Utility Functions:
* Added a `centroid` function to compute the centroid of a set of points and an updated `get_convex_hull` function for computing the convex hull of a set of points. (`src/meshing/utils.jl`) [[1]](diffhunk://#diff-897ee1a643506a737bd1edfaba7eafad6c60f14c3c8462bce56aebcd3ddb5decL23-R85) [[2]](diffhunk://#diff-897ee1a643506a737bd1edfaba7eafad6c60f14c3c8462bce56aebcd3ddb5decR141-R166)